### PR TITLE
Bump wavefront proxy version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
     <signalfx.protoc.version>0.0.23</signalfx.protoc.version>
     <typesafe.config.version>1.2.1</typesafe.config.version>
     <vertx.core.version>2.1.6</vertx.core.version>
-    <wavefront.version>3.13</wavefront.version>
+    <wavefront.version>3.20</wavefront.version>
     <wiremock.version>1.57</wiremock.version>
 
     <!--Plugin versions-->
@@ -601,11 +601,6 @@
     <dependency>
       <groupId>com.wavefront</groupId>
       <artifactId>proxy</artifactId>
-      <version>${wavefront.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.wavefront</groupId>
-      <artifactId>java-lib</artifactId>
       <version>${wavefront.version}</version>
     </dependency>
     <!-- Test - General -->

--- a/src/main/java/com/arpnetworking/tsdcore/sinks/WavefrontSink.java
+++ b/src/main/java/com/arpnetworking/tsdcore/sinks/WavefrontSink.java
@@ -23,6 +23,7 @@ import com.arpnetworking.tsdcore.model.PeriodicData;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.wavefront.agent.PointHandler;
+import com.wavefront.agent.PointHandlerImpl;
 import com.wavefront.agent.PushAgent;
 import net.sf.oval.constraint.NotEmpty;
 import net.sf.oval.constraint.NotNull;
@@ -351,7 +352,7 @@ public final class WavefrontSink extends BaseSink {
         }
 
         PointHandler createPointHandler() {
-            return new PointHandler(-1, pushValidationLevel, pushFlushMaxPoints, getFlushTasks(-1));
+            return new PointHandlerImpl(-1, pushValidationLevel, pushFlushMaxPoints, getFlushTasks(-1));
         }
     }
 }


### PR DESCRIPTION
Wavefront said:

> This rare case affecting stuck threads is something we very recently became aware of and have already taken the proper steps to alleviate this issue with a new agent build (3.20). The next step forward is to upgrade your entire fleet of proxy agents from 3.13 to 3.20 at your earliest convenience.

So here we are :)

We're currently using 3.20 in our installation, wavefront reports no more 'stuck threads'.