### PR TITLE
Add whitelisting to the dimensions filter.

### DIFF
--- a/src/test/java/com/arpnetworking/tsdcore/sinks/DimensionFilteringSinkTest.java
+++ b/src/test/java/com/arpnetworking/tsdcore/sinks/DimensionFilteringSinkTest.java
@@ -86,6 +86,32 @@ public class DimensionFilteringSinkTest {
         Mockito.verify(_target).recordAggregateData(dataIncluded);
     }
 
+    @Test
+    public void testWhistlist() {
+        final DimensionFilteringSink sink = new DimensionFilteringSink.Builder()
+                .setName("testWhistlist")
+                .setSink(_target)
+                .setWhitelistDimensions(ImmutableSet.of("foo", "bar"))
+                .build();
+        final PeriodicData dataExcluded = TestBeanFactory.createPeriodicDataBuilder()
+                .setDimensions(ImmutableMap.of("foo", "fooVal", "baz", "bazVal"))
+                .build();
+        sink.recordAggregateData(dataExcluded);
+        Mockito.verify(_target, Mockito.never()).recordAggregateData(Mockito.any(PeriodicData.class));
+
+        final PeriodicData dataIncluded = TestBeanFactory.createPeriodicDataBuilder()
+                .setDimensions(ImmutableMap.of("foo", "fooVal", "bar", "barVal"))
+                .build();
+        sink.recordAggregateData(dataIncluded);
+        Mockito.verify(_target).recordAggregateData(dataIncluded);
+
+        final PeriodicData dataIncluded2 = TestBeanFactory.createPeriodicDataBuilder()
+                .setDimensions(ImmutableMap.of("bar", "barVal"))
+                .build();
+        sink.recordAggregateData(dataIncluded2);
+        Mockito.verify(_target).recordAggregateData(dataIncluded2);
+    }
+
     @Mock
     private Sink _target;
 }

--- a/src/test/java/com/arpnetworking/tsdcore/sinks/DimensionFilteringSinkTest.java
+++ b/src/test/java/com/arpnetworking/tsdcore/sinks/DimensionFilteringSinkTest.java
@@ -87,14 +87,14 @@ public class DimensionFilteringSinkTest {
     }
 
     @Test
-    public void testWhistlist() {
+    public void testWhitelist() {
         final DimensionFilteringSink sink = new DimensionFilteringSink.Builder()
-                .setName("testWhistlist")
+                .setName("testWhitelist")
                 .setSink(_target)
                 .setWhitelistDimensions(ImmutableSet.of("foo", "bar"))
                 .build();
         final PeriodicData dataExcluded = TestBeanFactory.createPeriodicDataBuilder()
-                .setDimensions(ImmutableMap.of("foo", "fooVal", "baz", "bazVal"))
+                .setDimensions(ImmutableMap.of("foo", "fooVal", "abc", "abcVal"))
                 .build();
         sink.recordAggregateData(dataExcluded);
         Mockito.verify(_target, Mockito.never()).recordAggregateData(Mockito.any(PeriodicData.class));


### PR DESCRIPTION
Allow the filtering of metrics with custom dimensions, so that 'legacy sinks', or those which have no ability to process dimensions, can be prevented from receiving data with custom dimensions, i.e. dimensions beyond `service`, `cluster` and `host`.