### PR TITLE
Use round-robin pool for cluster emitter, too.

### DIFF
--- a/src/main/java/com/arpnetworking/clusteraggregator/GuiceModule.java
+++ b/src/main/java/com/arpnetworking/clusteraggregator/GuiceModule.java
@@ -144,7 +144,7 @@ public class GuiceModule extends AbstractModule {
     @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD") // Invoked reflectively by Guice
     private ActorRef provideClusterEmitter(final Injector injector, final ActorSystem system) {
         final ActorRef emitterConfigurationProxy = system.actorOf(
-                ConfigurableActorProxy.props(Emitter::props),
+                ConfigurableActorProxy.props(new RoundRobinEmitterFactory()),
                 "cluster-emitter-configurator");
         final ActorConfigurator<EmitterConfiguration> configurator =
                 new ActorConfigurator<>(emitterConfigurationProxy, EmitterConfiguration.class);


### PR DESCRIPTION
... to be consistent with the host emitter. We've been using this at Groupon for a few months now to allow the cluster emitter to keep up with the load and access more CPU resources.