### PR TITLE
fix test

### DIFF
--- a/src/test/java/com/arpnetworking/tsdcore/sinks/WavefrontSinkTest.java
+++ b/src/test/java/com/arpnetworking/tsdcore/sinks/WavefrontSinkTest.java
@@ -78,7 +78,7 @@ public class WavefrontSinkTest extends BaseActorTest {
                 .setBufferBasename("target/buffer")
                 .build();
 
-        final DateTime start = new DateTime(1445313091000L);
+        final DateTime start = DateTime.now();
         final PeriodicData periodicData = TestBeanFactory.createPeriodicDataBuilder()
                 .setPeriod(Period.seconds(1))
                 .setStart(start)


### PR DESCRIPTION
The wavefront sink will reject points with a date that is more than 1 year old.