### PR TITLE
Switched from Java serialization to Kyro serialization for remoting.

### DIFF
--- a/config/config.hocon
+++ b/config/config.hocon
@@ -42,11 +42,25 @@ databaseConfigurations {
 }
 akkaConfiguration {
   akka {
+    extensions=["com.romix.akka.serialization.kryo.KryoSerializationExtension$"]
     loggers=["akka.event.slf4j.Slf4jLogger"]
     loglevel="DEBUG"
     stdout-loglevel="DEBUG"
     logging-filter="akka.event.slf4j.Slf4jLoggingFilter"
     actor {
+      serializers {
+        kryo="com.romix.akka.serialization.kryo.KryoSerializer"
+      }
+      serialization-bindings {
+        "java.lang.Object"="kryo"
+        "java.io.Serializable"="none"
+      }
+      kryo {
+        type="graph"
+        idstrategy="default"
+        buffer-size=4096
+        max-buffer-size=-1
+      }
       debug {
         unhandled="on"
       }

--- a/pom.xml
+++ b/pom.xml
@@ -101,9 +101,10 @@
 
   <properties>
     <!--Dependency versions-->
-    <akka.version>2.4.2</akka.version>
-    <akka.http.version>2.4.2</akka.http.version>
+    <akka.version>2.4.14</akka.version>
+    <akka.http.version>2.4.11</akka.http.version>
     <akka.persistence.cassandra.version>0.6</akka.persistence.cassandra.version>
+    <akka.kryo.version>0.5.0</akka.kryo.version>
     <apache.httpclient.version>4.5.1</apache.httpclient.version>
     <apache.httpcore.version>4.4.3</apache.httpcore.version>
     <arpnetworking.commons.version>1.7.1</arpnetworking.commons.version>
@@ -615,6 +616,12 @@
       <groupId>org.fusesource.leveldbjni</groupId>
       <artifactId>leveldbjni-all</artifactId>
       <version>${leveldb.jni.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.romix.akka</groupId>
+      <artifactId>akka-kryo-serialization_${scala.version}</artifactId>
+      <version>${akka.kryo.version}</version>
       <scope>runtime</scope>
     </dependency>
     <!-- Database -->

--- a/src/main/java/com/arpnetworking/clusteraggregator/models/StatusResponse.java
+++ b/src/main/java/com/arpnetworking/clusteraggregator/models/StatusResponse.java
@@ -295,13 +295,17 @@ public final class StatusResponse {
          * {@inheritDoc}
          */
         @Override
-        public void serialize(final Member value, final JsonGenerator gen, final SerializerProvider serializers) throws IOException {
+        public void serialize(
+                final Member value,
+                final JsonGenerator gen,
+                final SerializerProvider serializers)
+                throws IOException {
             gen.writeStartObject();
             gen.writeStringField("address", value.address().toString());
             gen.writeObjectField("roles", JavaConversions.setAsJavaSet(value.roles()));
             gen.writeNumberField("upNumber", value.upNumber());
             gen.writeStringField("status", value.status().toString());
-            gen.writeNumberField("uniqueAddress", value.uniqueAddress().uid());
+            gen.writeNumberField("uniqueAddress", value.uniqueAddress().longUid());
             gen.writeEndObject();
         }
     }


### PR DESCRIPTION
To debug serialization (test only) add this under "akka" in config.json:
```
"serialize-messages": "on"
```

More information on configuring serialization here: http://doc.akka.io/docs/akka/2.4/java/serialization.html

And regarding the Kyro serializer here:
https://github.com/romix/akka-kryo-serialization

The protostuff and quickser serializers were considered, but Kyro was the only one in Maven Central with reasonable maintenance record. Unlike protobuf it does not require any separation of serialized classes. However, this is a double edged sword. 

We should separate our actor messages from our regular data model. Not saying we should switch to Protobuf, but rather we have a separate modeling issues and not blocking this and #47 on it I used Kryo to just serialize everything.