### PR TITLE
Fix map duplicates

### DIFF
--- a/src/main/java/com/arpnetworking/clusteraggregator/client/AggClientConnection.java
+++ b/src/main/java/com/arpnetworking/clusteraggregator/client/AggClientConnection.java
@@ -45,6 +45,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * An actor that handles the data sent from an agg client.
@@ -194,14 +196,14 @@ public class AggClientConnection extends UntypedActor {
         final ImmutableList.Builder<AggregatedData> builder = ImmutableList.builder();
         final Map<String, String> dimensionsMap = setRecord.getDimensionsMap();
 
-        final Stream<Map.Entry<String, String>> fred = dimensionsMap.entrySet().stream().filter(entry ->
+        final Stream<Map.Entry<String, String>> dimensionStream = dimensionsMap.entrySet().stream().filter(entry ->
                 !CombinedMetricData.HOST_KEY.equals(entry.getKey())
                         && !CombinedMetricData.SERVICE_KEY.equals(entry.getKey())
                         && !CombinedMetricData.CLUSTER_KEY.equals(entry.getKey())
         );
 
         final ImmutableMap.Builder<String, String> dimensionBuilder = ImmutableMap.<String, String>builder()
-                .putAll(fred.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+                .putAll(dimensionStream.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
 
         Optional<String> host = Optional.ofNullable(dimensionsMap.get(CombinedMetricData.HOST_KEY));
         Optional<String> service = Optional.ofNullable(dimensionsMap.get(CombinedMetricData.SERVICE_KEY));

--- a/src/main/java/com/arpnetworking/clusteraggregator/client/AggClientConnection.java
+++ b/src/main/java/com/arpnetworking/clusteraggregator/client/AggClientConnection.java
@@ -45,8 +45,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * An actor that handles the data sent from an agg client.
@@ -195,15 +193,16 @@ public class AggClientConnection extends UntypedActor {
         final CombinedMetricData combinedMetricData = CombinedMetricData.Builder.fromStatisticSetRecord(setRecord).build();
         final ImmutableList.Builder<AggregatedData> builder = ImmutableList.builder();
         final Map<String, String> dimensionsMap = setRecord.getDimensionsMap();
+        final ImmutableMap.Builder<String, String> dimensionBuilder = ImmutableMap.builder();
 
-        final Stream<Map.Entry<String, String>> dimensionStream = dimensionsMap.entrySet().stream().filter(entry ->
-                !CombinedMetricData.HOST_KEY.equals(entry.getKey())
+        dimensionsMap.entrySet().stream()
+                .filter(entry ->
+                        !CombinedMetricData.HOST_KEY.equals(entry.getKey())
                         && !CombinedMetricData.SERVICE_KEY.equals(entry.getKey())
-                        && !CombinedMetricData.CLUSTER_KEY.equals(entry.getKey())
-        );
-
-        final ImmutableMap.Builder<String, String> dimensionBuilder = ImmutableMap.<String, String>builder()
-                .putAll(dimensionStream.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+                        && !CombinedMetricData.CLUSTER_KEY.equals(entry.getKey()))
+                .forEach(dim ->
+                        dimensionBuilder.put(dim.getKey(), dim.getValue()
+                ));
 
         Optional<String> host = Optional.ofNullable(dimensionsMap.get(CombinedMetricData.HOST_KEY));
         Optional<String> service = Optional.ofNullable(dimensionsMap.get(CombinedMetricData.SERVICE_KEY));

--- a/src/main/java/com/arpnetworking/clusteraggregator/client/AggClientConnection.java
+++ b/src/main/java/com/arpnetworking/clusteraggregator/client/AggClientConnection.java
@@ -193,7 +193,15 @@ public class AggClientConnection extends UntypedActor {
         final CombinedMetricData combinedMetricData = CombinedMetricData.Builder.fromStatisticSetRecord(setRecord).build();
         final ImmutableList.Builder<AggregatedData> builder = ImmutableList.builder();
         final Map<String, String> dimensionsMap = setRecord.getDimensionsMap();
-        final ImmutableMap.Builder<String, String> dimensionBuilder = ImmutableMap.<String, String>builder().putAll(dimensionsMap);
+
+        final Stream<Map.Entry<String, String>> fred = dimensionsMap.entrySet().stream().filter(entry ->
+                !CombinedMetricData.HOST_KEY.equals(entry.getKey())
+                        && !CombinedMetricData.SERVICE_KEY.equals(entry.getKey())
+                        && !CombinedMetricData.CLUSTER_KEY.equals(entry.getKey())
+        );
+
+        final ImmutableMap.Builder<String, String> dimensionBuilder = ImmutableMap.<String, String>builder()
+                .putAll(fred.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
 
         Optional<String> host = Optional.ofNullable(dimensionsMap.get(CombinedMetricData.HOST_KEY));
         Optional<String> service = Optional.ofNullable(dimensionsMap.get(CombinedMetricData.SERVICE_KEY));


### PR DESCRIPTION
The problem occurs if service, cluster or host is manually set as a dimension.  Immutable Map build does not replace duplicate keys with the more recently added value.  After merging to a fork of CAgg, I was getting an error on the build call about duplicate host keys.  In my case the value for the key was always the same, so it is likely related to the MAD version (which I plan to merge next).

https://google.github.io/guava/releases/21.0/api/docs/com/google/common/collect/ImmutableMap.Builder.html#put-K-V-

Maybe this is not the method you would prefer but it is what I wrote quick to fix the errors I was seeing.