### PR TITLE
Add support for dedicated HTTP endpoints (paths) which either persist or reaggregate.

### DIFF
--- a/src/main/java/com/arpnetworking/clusteraggregator/http/Routes.java
+++ b/src/main/java/com/arpnetworking/clusteraggregator/http/Routes.java
@@ -161,7 +161,9 @@ public final class Routes implements Function<HttpRequest, CompletionStage<HttpR
                                 });
             }
         } else if (HttpMethods.POST.equals(request.method())) {
-            if (INCOMING_DATA_V1_PATH.equals(request.getUri().path())) {
+            if (INCOMING_DATA_V1_PATH.equals(request.getUri().path())
+                    || INCOMING_DATA_PERSIST_V1_PATH.equals(request.getUri().path())
+                    || INCOMING_DATA_REAGGREGATE_V1_PATH.equals(request.getUri().path())) {
                 return ask("/user/http-ingest-v1", request, HttpResponse.create().withStatus(500));
             }
         }
@@ -210,7 +212,6 @@ public final class Routes implements Function<HttpRequest, CompletionStage<HttpR
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Routes.class);
 
-    // Ping
     private static final HttpHeader PING_CACHE_CONTROL_HEADER = CacheControl.create(
             CacheDirectives.PRIVATE(),
             CacheDirectives.NO_CACHE,
@@ -218,7 +219,6 @@ public final class Routes implements Function<HttpRequest, CompletionStage<HttpR
             CacheDirectives.MUST_REVALIDATE);
     private static final String UNHEALTHY_STATE = "UNHEALTHY";
     private static final String HEALTHY_STATE = "HEALTHY";
-    private static final String INCOMING_DATA_V1_PATH = "/metrics/v1/data";
     private static final String REST_SERVICE_METRIC_ROOT = "rest_service/";
     private static final String BODY_SIZE_METRIC = "body_size";
     private static final String REQUEST_METRIC = "request";
@@ -228,6 +228,29 @@ public final class Routes implements Function<HttpRequest, CompletionStage<HttpR
     private static final ContentType JSON_CONTENT_TYPE = ContentTypes.APPLICATION_JSON;
 
     private static final long serialVersionUID = -1573473630801540757L;
+    
+    /**
+     * The legacy path for incoming data over HTTP. The reaggregation behavior
+     * on this path is controlled by the the {@code calculateClusterAggregations}
+     * value. If this is set to {@code False} this endpoint behaves with
+     * {@link com.arpnetworking.clusteraggregator.models.AggregationMode} set to
+     * {@code PERSIST}. If the configuration key is set to {@code True} this endpoint
+     * behaves with {@link com.arpnetworking.clusteraggregator.models.AggregationMode}
+     * set to {@code PERSIST_AND_REAGGREGATE}.
+     */
+    public static final String INCOMING_DATA_V1_PATH = "/metrics/v1/data";
+
+    /**
+     * This HTTP endpoint is for only persisting data directly and through the
+     * host emitter.
+     */
+    public static final String INCOMING_DATA_PERSIST_V1_PATH = "/metrics/v1/data/persist";
+
+    /**
+     * This HTTP endpoint is for only reaggregating data and then persisting
+     * through the cluster emitter.
+     */
+    public static final String INCOMING_DATA_REAGGREGATE_V1_PATH = "/metrics/v1/data/reaggregate";
 
     private static class MemberSerializer extends JsonSerializer<Member> {
         @Override

--- a/src/main/java/com/arpnetworking/clusteraggregator/models/AggregationMode.java
+++ b/src/main/java/com/arpnetworking/clusteraggregator/models/AggregationMode.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.clusteraggregator.models;
+
+/**
+ * The aggregation mode applied to data.
+ *
+ * @author Ville Koskela (vkoskela at dropbox dot com)
+ */
+public enum AggregationMode {
+
+    /**
+     * Persist the statistics data as provided by the client.
+     */
+    PERSIST(true, false),
+
+    /**
+     * Reaggregate the statistics data provided by the client and persist only
+     * the reaggregated data.
+     */
+    REAGGREGATE(false, true),
+
+    /**
+     * Persist the statistics data as provided by the client <b>AND</b> reaggregate
+     * the statistics data provided by the client persisting the reaggregated data
+     * as well.
+     */
+    PERSIST_AND_REAGGREGATE(true, true);
+
+    /**
+     * Whether this {@link AggregationMode} should persist client statistics.
+     *
+     * @return True if and only if client statistics should be persisted
+     */
+    public boolean shouldPersist() {
+        return _shouldPersist;
+    }
+
+    /**
+     * Whether this {@link AggregationMode} should reaggregate client statistics.
+     *
+     * @return True if and only if client statistics should be reaggregated
+     */
+    public boolean shouldReaggregate() {
+        return _shouldReaggregate;
+    }
+
+    AggregationMode(final boolean shouldPersist, final boolean shouldReaggregate) {
+        _shouldPersist = shouldPersist;
+        _shouldReaggregate = shouldReaggregate;
+    }
+
+    private final boolean _shouldPersist;
+    private final boolean _shouldReaggregate;
+}

--- a/src/main/java/com/arpnetworking/clusteraggregator/models/CombinedMetricData.java
+++ b/src/main/java/com/arpnetworking/clusteraggregator/models/CombinedMetricData.java
@@ -207,9 +207,9 @@ public final class CombinedMetricData {
 
                     final HistogramStatistic.HistogramSupportingData histogramSupportingData =
                             new HistogramStatistic.HistogramSupportingData.Builder()
-                            .setHistogramSnapshot(histogram.getSnapshot())
-                            .setUnit(getUnitFromName(supportingData.getUnit()))
-                            .build();
+                                    .setHistogramSnapshot(histogram.getSnapshot())
+                                    .setUnit(getUnitFromName(supportingData.getUnit()))
+                                    .build();
 
                     calculatedValueBuilder = new CalculatedValue.Builder<HistogramStatistic.HistogramSupportingData>()
                             .setData(histogramSupportingData);

--- a/src/main/java/com/arpnetworking/clusteraggregator/models/HttpRequest.java
+++ b/src/main/java/com/arpnetworking/clusteraggregator/models/HttpRequest.java
@@ -25,6 +25,11 @@ import com.google.common.collect.Multimap;
  * @author Brandon Arp (brandon dot arp at smartsheet dot com)
  */
 public final class HttpRequest {
+
+    public String getPath() {
+        return _path;
+    }
+
     public Multimap<String, String> getHeaders() {
         return _headers;
     }
@@ -36,14 +41,20 @@ public final class HttpRequest {
     /**
      * Public constructor.
      *
+     * @param path The path.
      * @param headers The headers.
      * @param body The body of the request.
      */
-    public HttpRequest(final ImmutableMultimap<String, String> headers, final ByteString body) {
+    public HttpRequest(
+            final String path,
+            final ImmutableMultimap<String, String> headers,
+            final ByteString body) {
+        _path = path;
         _headers = headers;
         _body = body;
     }
 
+    private final String _path;
     private final ImmutableMultimap<String, String> _headers;
     private final ByteString _body;
 }

--- a/src/main/java/com/arpnetworking/tsdcore/model/AggregationMessage.java
+++ b/src/main/java/com/arpnetworking/tsdcore/model/AggregationMessage.java
@@ -121,7 +121,7 @@ public final class AggregationMessage {
             }
         } catch (final InvalidProtocolBufferException e) {
             LOGGER.warn(
-                String.format("Invalid protocol buffer; type=%s bytes=%s", type, Hex.encodeHexString(payloadBytes)), e);
+                    String.format("Invalid protocol buffer; type=%s bytes=%s", type, Hex.encodeHexString(payloadBytes)), e);
             return Optional.empty();
         }
     }
@@ -190,5 +190,4 @@ public final class AggregationMessage {
     private static final int INTEGER_SIZE_IN_BYTES = Integer.SIZE / 8;
     private static final int HEADER_SIZE_IN_BYTES = INTEGER_SIZE_IN_BYTES + 1;
     private static final Logger LOGGER = LoggerFactory.getLogger(AggregationMessage.class);
-
 }

--- a/src/main/java/com/arpnetworking/tsdcore/model/AggregationRequest.java
+++ b/src/main/java/com/arpnetworking/tsdcore/model/AggregationRequest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.tsdcore.model;
+
+import com.arpnetworking.clusteraggregator.models.AggregationMode;
+import com.arpnetworking.commons.builder.OvalBuilder;
+import com.arpnetworking.logback.annotations.Loggable;
+import com.google.common.collect.ImmutableList;
+import net.sf.oval.constraint.NotNull;
+
+/**
+ * Encapsulates a {@code List} of {@link AggregationMessage} instances and
+ * an {@link AggregationMode} to be applied to those messages.
+ *
+ * @author Ville Koskela (vkoskela at dropbox dot com)
+ */
+@Loggable
+public final class AggregationRequest {
+
+    public ImmutableList<AggregationMessage> getAggregationMessages() {
+        return _aggregationMessages;
+    }
+
+    public AggregationMode getAggregationMode() {
+        return _aggregationMode;
+    }
+
+    private AggregationRequest(final Builder builder) {
+        _aggregationMessages = builder._aggregationMessages;
+        _aggregationMode = builder._aggregationMode;
+    }
+
+    private final ImmutableList<AggregationMessage> _aggregationMessages;
+    private final AggregationMode _aggregationMode;
+
+    /**
+     * {@code Builder} implementation for {@link AggregationRequest}.
+     */
+    public static final class Builder extends OvalBuilder<AggregationRequest> {
+
+        /**
+         * Public constructor.
+         */
+        public Builder() {
+            super(AggregationRequest::new);
+        }
+
+        /**
+         * Set the aggregation messages. Required. Cannot be null.
+         *
+         * @param aggregationMessages The aggregation messages.
+         * @return This instance of <code>Builder</code>.
+         */
+        public Builder setAggregationMessages(final ImmutableList<AggregationMessage> aggregationMessages) {
+            _aggregationMessages = aggregationMessages;
+            return this;
+        }
+
+        /**
+         * Set the aggregation mode. Required. Cannot be null.
+         *
+         * @param aggregationMode The aggregation mode.
+         * @return This instance of <code>Builder</code>.
+         */
+        public Builder setAggregationMode(final AggregationMode aggregationMode) {
+            _aggregationMode = aggregationMode;
+            return this;
+        }
+
+        @NotNull
+        private ImmutableList<AggregationMessage> _aggregationMessages;
+        @NotNull
+        private AggregationMode _aggregationMode;
+    }
+}


### PR DESCRIPTION
The implementation is not great. First, I took the view that the TCP protocol will eventually be deprecated and thus did not formally extend some of the data model concepts to include support for both. Second, I'm not attached in any way to the actual endpoint names or conceptual names in the code. 