### PR TITLE
Upgade the akka persistence plugin for cassandra

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <!--Dependency versions-->
     <akka.version>2.5.6</akka.version>
     <akka.http.version>10.0.6</akka.http.version>
-    <akka.persistence.cassandra.version>0.86</akka.persistence.cassandra.version>
+    <akka.persistence.cassandra.version>0.89</akka.persistence.cassandra.version>
     <akka.kryo.version>0.5.1</akka.kryo.version>
     <apache.httpclient.version>4.5.2</apache.httpclient.version>
     <apache.httpcore.version>4.4.5</apache.httpcore.version>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <!--Dependency versions-->
     <akka.version>2.5.6</akka.version>
     <akka.http.version>10.0.6</akka.http.version>
-    <akka.persistence.cassandra.version>0.54</akka.persistence.cassandra.version>
+    <akka.persistence.cassandra.version>0.7</akka.persistence.cassandra.version>
     <akka.kryo.version>0.5.1</akka.kryo.version>
     <apache.httpclient.version>4.5.2</apache.httpclient.version>
     <apache.httpcore.version>4.4.5</apache.httpcore.version>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <!--Dependency versions-->
     <akka.version>2.5.6</akka.version>
     <akka.http.version>10.0.6</akka.http.version>
-    <akka.persistence.cassandra.version>0.7</akka.persistence.cassandra.version>
+    <akka.persistence.cassandra.version>0.86</akka.persistence.cassandra.version>
     <akka.kryo.version>0.5.1</akka.kryo.version>
     <apache.httpclient.version>4.5.2</apache.httpclient.version>
     <apache.httpcore.version>4.4.5</apache.httpcore.version>
@@ -854,6 +854,12 @@
       <groupId>com.typesafe.akka</groupId>
       <artifactId>akka-testkit_${scala.version}</artifactId>
       <version>${akka.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.typesafe.akka</groupId>
+      <artifactId>akka-persistence-cassandra-launcher_${scala.version}</artifactId>
+      <version>${akka.persistence.cassandra.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
There is a separate plugin for cassandra 3.x but it is not backwards compatible. It's unclear what direction the author is taking.