### PR TITLE
Update config.conf

### DIFF
--- a/config/config.conf
+++ b/config/config.conf
@@ -64,7 +64,7 @@ akkaConfiguration {
       debug {
         unhandled="on"
       }
-      provider="akka.cluster.ClusterActorRefProvider"
+      provider="remote"
     }
     cluster {
       seed-nodes=["akka.tcp://Metrics@127.0.0.1:2551"]
@@ -84,9 +84,11 @@ akkaConfiguration {
         }
       }
     }
-    remote.log-remote-lifecycle-events="on"
-    remote.netty.tcp.hostname="127.0.0.1"
-    remote.netty.tcp.port=2551
+    remote {
+      log-remote-lifecycle-events="on"
+      netty.tcp.hostname="127.0.0.1"
+      netty.tcp.port=2551
+    }
     persistence {
       journal {
         plugin = "akka.persistence.journal.leveldb"


### PR DESCRIPTION
Reference: https://doc.akka.io/docs/akka/2.5/cluster-usage.html

^ Looks like the meaning of the actor provider changed with 2.5 although I didn't see it mentioned in the migration docs.