### PR TITLE
collapse unknown routes into a single family of metrics

### DIFF
--- a/src/test/java/com/arpnetworking/clusteraggregator/http/RoutesTest.java
+++ b/src/test/java/com/arpnetworking/clusteraggregator/http/RoutesTest.java
@@ -43,6 +43,8 @@ public class RoutesTest extends BaseActorTest {
     public void testApply() throws InterruptedException {
         final HttpRequest request = HttpRequest.create("test_health_check");
         _routes.apply(request);
+
+        // wait for the request to complete. The actor time out is 5 seconds so here wait for 6 seconds.
         Thread.sleep(6000);
 
         Mockito.verify(_mockMetricsFactory).create();
@@ -53,6 +55,8 @@ public class RoutesTest extends BaseActorTest {
 
         final HttpRequest unknownRequest = HttpRequest.create("kb23k1dnlkns02");
         _routes.apply(unknownRequest);
+
+        // wait for the request to complete. Since unknown_route will not call actor, don't have to wait for 6 seconds. 
         Thread.sleep(1000);
 
         Mockito.verify(_mockMetricsFactory, Mockito.times(2)).create();

--- a/src/test/java/com/arpnetworking/clusteraggregator/http/RoutesTest.java
+++ b/src/test/java/com/arpnetworking/clusteraggregator/http/RoutesTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 Groupon.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.clusteraggregator.http;
+
+import akka.http.javadsl.model.HttpRequest;
+import com.arpnetworking.metrics.Metrics;
+import com.arpnetworking.metrics.MetricsFactory;
+import com.arpnetworking.utility.BaseActorTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Tests for the <code>Routes</code> class.
+ *
+ * @author Qinyan Li (lqy520s at hotmail dot com)
+ */
+public class RoutesTest extends BaseActorTest {
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        _routes = new Routes(getSystem(), _mockMetricsFactory, HEALTH_CHECK_PATH, STATUS_PATH, VERSION_PATH);
+        Mockito.doReturn(_mockMetrics).when(_mockMetricsFactory).create();
+    }
+
+    @Test
+    public void testApply() throws InterruptedException {
+        final HttpRequest request = HttpRequest.create("test_health_check");
+        _routes.apply(request);
+        Thread.sleep(6000);
+
+        Mockito.verify(_mockMetricsFactory).create();
+        Mockito.verify(_mockMetrics).setTimer(Mockito.eq("rest_service/GET/test_health_check/request"), Mockito.anyLong(), Mockito.any());
+        Mockito.verify(_mockMetrics).setGauge(Mockito.eq("rest_service/GET/test_health_check/body_size"), Mockito.anyLong());
+        Mockito.verify(_mockMetrics).incrementCounter("rest_service/GET/test_health_check/status/5xx", 1);
+        Mockito.verify(_mockMetrics).close();
+
+        final HttpRequest unknownRequest = HttpRequest.create("kb23k1dnlkns02");
+        _routes.apply(unknownRequest);
+        Thread.sleep(1000);
+
+        Mockito.verify(_mockMetricsFactory, Mockito.times(2)).create();
+        Mockito.verify(_mockMetrics).setTimer(Mockito.eq("rest_service/GET/unknown_route/request"), Mockito.anyLong(), Mockito.any());
+        Mockito.verify(_mockMetrics).setGauge(Mockito.eq("rest_service/GET/unknown_route/body_size"), Mockito.anyLong());
+        Mockito.verify(_mockMetrics).incrementCounter("rest_service/GET/unknown_route/status/4xx", 1);
+        Mockito.verify(_mockMetrics, Mockito.times(2)).close();
+    }
+
+    private Routes _routes;
+
+    private static final String HEALTH_CHECK_PATH = "test_health_check";
+    private static final String STATUS_PATH = "test_status";
+    private static final String VERSION_PATH = "test_version";
+
+    @Mock
+    private Metrics _mockMetrics;
+    @Mock
+    private MetricsFactory _mockMetricsFactory;
+}


### PR DESCRIPTION
collapse all unknown routes into a single family of metrics where the route is unknown_route rather than the actual requested path