### PR TITLE
Changed entryCount from int to long in HistogramStatistic to prevent overflow

### DIFF
--- a/src/main/java/com/arpnetworking/tsdcore/statistics/HistogramStatistic.java
+++ b/src/main/java/com/arpnetworking/tsdcore/statistics/HistogramStatistic.java
@@ -342,7 +342,7 @@ public final class HistogramStatistic extends BaseStatistic {
             _packMask = (1 << (_precision + EXPONENT_BITS + 1)) - 1;
         }
 
-        private int _entriesCount = 0;
+        private long _entriesCount = 0;
         private final Double2LongSortedMap _data = new Double2LongAVLTreeMap();
         private final int _precision;
         private final long _truncateMask;


### PR DESCRIPTION
In the Histogram class used for calculations by the HistogramStatistic, the entry count variable is internally stored and computed as a 32-bit integer. This can lead to integer overflow when a significant number of samples are included in a single histogram. Additionally, when this value is exposed externally via a histogram snapshot [https://github.com/ArpNetworking/metrics-cluster-aggregator/blob/9bc654e8940963fcd4b4240dea93eb9c949bf68a/src/main/java/com/arpnetworking/tsdcore/statistics/HistogramStatistic.java#L175], the entries count is expected to be a 64-bit long integer.