### PR TITLE
Record samplesDropped and samplesSent metrics in HttpSink

### DIFF
--- a/src/main/java/com/arpnetworking/tsdcore/model/RequestEntry.java
+++ b/src/main/java/com/arpnetworking/tsdcore/model/RequestEntry.java
@@ -19,6 +19,7 @@ import com.arpnetworking.commons.builder.OvalBuilder;
 import net.sf.oval.constraint.NotNull;
 import org.asynchttpclient.Request;
 
+import java.time.Instant;
 import java.util.Optional;
 
 /**
@@ -31,7 +32,7 @@ public final class RequestEntry {
         return _request;
     }
 
-    public long getEnterTime() {
+    public Instant getEnterTime() {
         return _enterTime;
     }
 
@@ -46,7 +47,7 @@ public final class RequestEntry {
     }
 
     private final Request _request;
-    private final long _enterTime;
+    private final Instant _enterTime;
     private final Optional<Long> _populationSize;
 
     /**
@@ -82,7 +83,7 @@ public final class RequestEntry {
          * @param value The enter time.
          * @return This {@link Builder} instance.
          */
-        public Builder setEnterTime(final long value) {
+        public Builder setEnterTime(final Instant value) {
             _enterTime = value;
             return this;
         }
@@ -101,7 +102,7 @@ public final class RequestEntry {
         @NotNull
         private Request _request;
         @NotNull
-        private Long _enterTime;
+        private Instant _enterTime;
         @NotNull
         private Optional<Long> _populationSize = Optional.empty();
     }

--- a/src/main/java/com/arpnetworking/tsdcore/model/RequestEntry.java
+++ b/src/main/java/com/arpnetworking/tsdcore/model/RequestEntry.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Dropbox
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.tsdcore.model;
+
+import com.arpnetworking.commons.builder.OvalBuilder;
+import net.sf.oval.constraint.NotNull;
+import org.asynchttpclient.Request;
+
+import java.util.Optional;
+
+/**
+ * Contains the info for a http request.
+ *
+ * @author Qinyan Li (lqy520s at hotmail dot com)
+ */
+public final class RequestEntry {
+    public Request getRequest() {
+        return _request;
+    }
+
+    public long getEnterTime() {
+        return _enterTime;
+    }
+
+    public Optional<Long> getPopulationSize() {
+        return _populationSize;
+    }
+
+    private RequestEntry(final Builder builder) {
+        _request = builder._request;
+        _enterTime = builder._enterTime;
+        _populationSize = builder._populationSize;
+    }
+
+    private final Request _request;
+    private final long _enterTime;
+    private final Optional<Long> _populationSize;
+
+    /**
+     * {@link com.arpnetworking.commons.builder.Builder} implementation for
+     * {@link RequestEntry}.
+     *
+     * TODO(ville): Convert RequestEntry.Builder would be a ThreadLocalBuilder
+     * See comments in HttpPostSink:createRequests
+     */
+    public static final class Builder extends OvalBuilder<RequestEntry> {
+
+        /**
+         * Public constructor.
+         */
+        public Builder() {
+            super(RequestEntry::new);
+        }
+
+        /**
+         * Set the request. Required. Cannot be null.
+         *
+         * @param value The request.
+         * @return This {@link Builder} instance.
+         */
+        public Builder setRequest(final Request value) {
+            _request = value;
+            return this;
+        }
+
+        /**
+         * Set the time when the request enter the pending request queue. Required. Cannot be null.
+         *
+         * @param value The enter time.
+         * @return This {@link Builder} instance.
+         */
+        public Builder setEnterTime(final long value) {
+            _enterTime = value;
+            return this;
+        }
+
+        /**
+         * Set the population size of the request. Optional. Cannot be null.
+         *
+         * @param value The population size.
+         * @return This {@link Builder} instance.
+         */
+        public Builder setPopulationSize(final Optional<Long> value) {
+            _populationSize = value;
+            return this;
+        }
+
+        @NotNull
+        private Request _request;
+        @NotNull
+        private Long _enterTime;
+        @NotNull
+        private Optional<Long> _populationSize = Optional.empty();
+    }
+}
+

--- a/src/main/java/com/arpnetworking/tsdcore/sinks/DataDogSink.java
+++ b/src/main/java/com/arpnetworking/tsdcore/sinks/DataDogSink.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Publishes aggregations to Data Dog. This class is thread safe.
@@ -63,7 +64,7 @@ public final class DataDogSink extends HttpPostSink {
     }
 
     @Override
-    protected Collection<byte[]> serialize(final PeriodicData periodicData) {
+    protected Collection<SerializedDatum> serialize(final PeriodicData periodicData) {
         final String period = periodicData.getPeriod().toString();
         final long timestamp = (periodicData.getStart().toInstant().toEpochMilli()
                 + periodicData.getPeriod().toMillis()) / 1000;
@@ -94,7 +95,9 @@ public final class DataDogSink extends HttpPostSink {
                     .log();
             return Collections.emptyList();
         }
-        return Collections.singletonList(dataDogDataAsJson.getBytes(Charsets.UTF_8));
+        return Collections.singletonList(new SerializedDatum(
+                dataDogDataAsJson.getBytes(Charsets.UTF_8),
+                Optional.empty()));
     }
 
     private static List<String> createTags(final PeriodicData periodicData, final AggregatedData datum) {

--- a/src/main/java/com/arpnetworking/tsdcore/sinks/HttpSinkActor.java
+++ b/src/main/java/com/arpnetworking/tsdcore/sinks/HttpSinkActor.java
@@ -33,7 +33,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import org.asynchttpclient.AsyncCompletionHandler;
 import org.asynchttpclient.AsyncHttpClient;
-import org.asynchttpclient.Request;
 import org.asynchttpclient.Response;
 import scala.concurrent.duration.FiniteDuration;
 

--- a/src/main/java/com/arpnetworking/tsdcore/sinks/KMonDSink.java
+++ b/src/main/java/com/arpnetworking/tsdcore/sinks/KMonDSink.java
@@ -39,6 +39,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Publishes aggregations to KMonD. This class is thread safe.
@@ -64,13 +65,13 @@ public final class KMonDSink extends HttpPostSink {
     }
 
     @Override
-    protected Collection<byte[]> serialize(final PeriodicData periodicData) {
+    protected Collection<SerializedDatum> serialize(final PeriodicData periodicData) {
         final Duration period = periodicData.getPeriod();
         final Multimap<String, AggregatedData> indexedData = prepareData(periodicData);
         final Multimap<String, Condition> indexedConditions = prepareConditions(periodicData.getConditions());
 
         // Serialize
-        final List<byte[]> serializedData = Lists.newArrayListWithCapacity(indexedData.size());
+        final List<SerializedDatum> serializedData = Lists.newArrayListWithCapacity(indexedData.size());
         final StringBuilder stringBuilder = new StringBuilder();
         for (final String key : indexedData.keySet()) {
             final Collection<AggregatedData> namedData = indexedData.get(key);
@@ -126,7 +127,9 @@ public final class KMonDSink extends HttpPostSink {
                         .append(dataBuilder.toString());
 
                 stringBuilder.setLength(stringBuilder.length() - 3);
-                serializedData.add(stringBuilder.toString().getBytes(Charset.forName("UTF-8")));
+                serializedData.add(new SerializedDatum(
+                        stringBuilder.toString().getBytes(Charset.forName("UTF-8")),
+                        Optional.empty()));
             }
         }
 

--- a/src/main/java/com/arpnetworking/tsdcore/sinks/KairosDbSink.java
+++ b/src/main/java/com/arpnetworking/tsdcore/sinks/KairosDbSink.java
@@ -47,6 +47,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Publishes to a KairosDbSink endpoint. This class is thread safe.
@@ -73,10 +75,11 @@ public final class KairosDbSink extends HttpPostSink {
     }
 
     @Override
-    protected Collection<byte[]> serialize(final PeriodicData periodicData) {
+    protected Collection<SerializedDatum> serialize(final PeriodicData periodicData) {
         // Initialize serialization structures
-        final List<byte[]> completeChunks = Lists.newArrayList();
+        final List<SerializedDatum> completeChunks = Lists.newArrayList();
         final ByteBuffer currentChunk = ByteBuffer.allocate(_maxRequestSize);
+        final AtomicLong currentChunkPopulationSize = new AtomicLong(0L);
         final ByteArrayOutputStream chunkStream = new ByteArrayOutputStream();
 
         // Extract and transform shared data
@@ -118,12 +121,12 @@ public final class KairosDbSink extends HttpPostSink {
             }
 
             if (_publishStandardMetrics && !(statistic instanceof HistogramStatistic)) {
-                serializer.serializeDatum(completeChunks, currentChunk, chunkStream, datum);
+                serializer.serializeDatum(completeChunks, currentChunk, chunkStream, datum, currentChunkPopulationSize);
             }
         }
 
         if (_publishHistograms && histogram != null) {
-            serializer.serializeHistogram(completeChunks, currentChunk, chunkStream, histogram, histogramAdditionalData);
+            serializer.serializeHistogram(completeChunks, currentChunk, chunkStream, histogram, histogramAdditionalData, currentChunkPopulationSize);
         } else if (_publishHistograms) {
             NO_HISTOGRAM_LOGGER.warn()
                     .setMessage("Expected to publish histogram, but none found")
@@ -133,13 +136,15 @@ public final class KairosDbSink extends HttpPostSink {
 
         // Add conditions
         for (final Condition condition : periodicData.getConditions()) {
-            serializer.serializeCondition(completeChunks, currentChunk, chunkStream, condition);
+            serializer.serializeCondition(completeChunks, currentChunk, chunkStream, condition, currentChunkPopulationSize);
         }
 
         // Add the current chunk (if any) to the completed chunks
         if (currentChunk.position() > HEADER_BYTE_LENGTH) {
             currentChunk.put(currentChunk.position() - 1, FOOTER);
-            completeChunks.add(Arrays.copyOf(currentChunk.array(), currentChunk.position()));
+            completeChunks.add(new SerializedDatum(
+                    Arrays.copyOf(currentChunk.array(), currentChunk.position()),
+                    Optional.of(currentChunkPopulationSize.get())));
         }
 
         return completeChunks;
@@ -148,7 +153,9 @@ public final class KairosDbSink extends HttpPostSink {
     private void addChunk(
             final ByteArrayOutputStream chunkStream,
             final ByteBuffer currentChunk,
-            final Collection<byte[]> completedChunks) {
+            final Collection<SerializedDatum> completedChunks,
+            final long populationSize,
+            final AtomicLong currentChunkPopulationSize) {
         final byte[] nextChunk = chunkStream.toByteArray();
         final int nextChunkSize = nextChunk.length;
         if (currentChunk.position() + nextChunkSize > _maxRequestSize) {
@@ -157,10 +164,13 @@ public final class KairosDbSink extends HttpPostSink {
 
                 // Copy the relevant part of the buffer
                 currentChunk.put(currentChunk.position() - 1, FOOTER);
-                completedChunks.add(Arrays.copyOf(currentChunk.array(), currentChunk.position()));
+                completedChunks.add(new SerializedDatum(
+                        Arrays.copyOf(currentChunk.array(), currentChunk.position()),
+                        Optional.of(currentChunkPopulationSize.get())));
 
                 // Truncate all but the beginning '[' to prepare the next entries
                 currentChunk.clear();
+                currentChunkPopulationSize.set(0L);
                 currentChunk.put(HEADER);
             } else {
                 CHUNK_TOO_BIG_LOGGER.warn()
@@ -174,6 +184,7 @@ public final class KairosDbSink extends HttpPostSink {
         }
 
         currentChunk.put(nextChunk);
+        currentChunkPopulationSize.addAndGet(populationSize);
         currentChunk.put(SEPARATOR);
         chunkStream.reset();
     }
@@ -256,10 +267,11 @@ public final class KairosDbSink extends HttpPostSink {
         }
 
         public void serializeDatum(
-                final List<byte[]> completeChunks,
+                final List<SerializedDatum> completeChunks,
                 final ByteBuffer currentChunk,
                 final ByteArrayOutputStream chunkStream,
-                final AggregatedData datum) {
+                final AggregatedData datum,
+                final AtomicLong currentChunkPopulationSize) {
             final String name = _serializedPeriod
                     + "/" + datum.getFQDSN().getMetric()
                     + "/" + datum.getFQDSN().getStatistic().getName();
@@ -288,7 +300,7 @@ public final class KairosDbSink extends HttpPostSink {
 
                 chunkGenerator.close();
 
-                addChunk(chunkStream, currentChunk, completeChunks);
+                addChunk(chunkStream, currentChunk, completeChunks, datum.getPopulationSize(), currentChunkPopulationSize);
             } catch (final IOException e) {
                 SERIALIZATION_FAILURE_LOGGER.error()
                         .setMessage("Serialization failure")
@@ -299,11 +311,12 @@ public final class KairosDbSink extends HttpPostSink {
         }
 
        public void serializeHistogram(
-               final List<byte[]> completeChunks,
+               final List<SerializedDatum> completeChunks,
                final ByteBuffer currentChunk,
                final ByteArrayOutputStream chunkStream,
                final AggregatedData data,
-               final KairosHistogramAdditionalData additionalData) {
+               final KairosHistogramAdditionalData additionalData,
+               final AtomicLong currentChunkPopulationSize) {
            final FQDSN fqdsn = data.getFQDSN();
 
            try {
@@ -347,7 +360,7 @@ public final class KairosDbSink extends HttpPostSink {
 
                 chunkGenerator.close();
 
-                addChunk(chunkStream, currentChunk, completeChunks);
+                addChunk(chunkStream, currentChunk, completeChunks, data.getPopulationSize(), currentChunkPopulationSize);
             } catch (final IOException e) {
                 SERIALIZATION_FAILURE_LOGGER.error()
                         .setMessage("Serialization failure")
@@ -358,10 +371,11 @@ public final class KairosDbSink extends HttpPostSink {
         }
 
         public void serializeCondition(
-                final List<byte[]> completeChunks,
+                final List<SerializedDatum> completeChunks,
                 final ByteBuffer currentChunk,
                 final ByteArrayOutputStream chunkStream,
-                final Condition condition) {
+                final Condition condition,
+                final AtomicLong currentChunkPopulationSize) {
             final String conditionName = _serializedPeriod
                     + "/" + condition.getFQDSN().getMetric()
                     + "/" + condition.getFQDSN().getStatistic().getName()
@@ -370,11 +384,11 @@ public final class KairosDbSink extends HttpPostSink {
                     + "/status";
             try {
                 // Value for condition threshold
-                serializeConditionThreshold(completeChunks, currentChunk, chunkStream, condition, conditionName);
+                serializeConditionThreshold(completeChunks, currentChunk, chunkStream, condition, conditionName, currentChunkPopulationSize);
 
                 if (condition.isTriggered().isPresent()) {
                     // Value for condition trigger (or status)
-                    serializeConditionStatus(completeChunks, currentChunk, chunkStream, condition, conditionStatusName);
+                    serializeConditionStatus(completeChunks, currentChunk, chunkStream, condition, conditionStatusName, currentChunkPopulationSize);
 
                 }
             } catch (final IOException e) {
@@ -387,11 +401,12 @@ public final class KairosDbSink extends HttpPostSink {
         }
 
         private void serializeConditionStatus(
-                final List<byte[]> completeChunks,
+                final List<SerializedDatum> completeChunks,
                 final ByteBuffer currentChunk,
                 final ByteArrayOutputStream chunkStream,
                 final Condition condition,
-                final String conditionStatusName)
+                final String conditionStatusName,
+                final AtomicLong currentChunkPopulationSize)
                 throws IOException {
             // 0 = Not triggered
             // 1 = Triggered
@@ -419,15 +434,16 @@ public final class KairosDbSink extends HttpPostSink {
 
             chunkGenerator.close();
 
-            addChunk(chunkStream, currentChunk, completeChunks);
+            addChunk(chunkStream, currentChunk, completeChunks, 0L, currentChunkPopulationSize);
         }
 
         private void serializeConditionThreshold(
-                final List<byte[]> completeChunks,
+                final List<SerializedDatum> completeChunks,
                 final ByteBuffer currentChunk,
                 final ByteArrayOutputStream chunkStream,
                 final Condition condition,
-                final String conditionName)
+                final String conditionName,
+                final AtomicLong currentChunkPopulationSize)
                 throws IOException {
             final JsonGenerator chunkGenerator = OBJECT_MAPPER.getFactory().createGenerator(chunkStream, JsonEncoding.UTF8);
 
@@ -450,7 +466,7 @@ public final class KairosDbSink extends HttpPostSink {
 
             chunkGenerator.close();
 
-            addChunk(chunkStream, currentChunk, completeChunks);
+            addChunk(chunkStream, currentChunk, completeChunks, 0L, currentChunkPopulationSize);
         }
 
         private final long _timestamp;

--- a/src/main/java/com/arpnetworking/tsdcore/sinks/KairosDbSink.java
+++ b/src/main/java/com/arpnetworking/tsdcore/sinks/KairosDbSink.java
@@ -85,8 +85,7 @@ public final class KairosDbSink extends HttpPostSink {
         // Extract and transform shared data
         final long timestamp = periodicData.getStart().plus(periodicData.getPeriod()).toInstant().toEpochMilli();
         final String serializedPeriod = periodicData.getPeriod().toString();
-        final ImmutableMap<String, String> dimensions = periodicData.getDimensions();
-        final Serializer serializer = new Serializer(timestamp, serializedPeriod, dimensions);
+        final Serializer serializer = new Serializer(timestamp, serializedPeriod, periodicData.getDimensions());
 
         final KairosHistogramAdditionalData histogramAdditionalData = new KairosHistogramAdditionalData();
         AggregatedData histogram = null;
@@ -126,7 +125,13 @@ public final class KairosDbSink extends HttpPostSink {
         }
 
         if (_publishHistograms && histogram != null) {
-            serializer.serializeHistogram(completeChunks, currentChunk, chunkStream, histogram, histogramAdditionalData, currentChunkPopulationSize);
+            serializer.serializeHistogram(
+                    completeChunks,
+                    currentChunk,
+                    chunkStream,
+                    histogram,
+                    histogramAdditionalData,
+                    currentChunkPopulationSize);
         } else if (_publishHistograms) {
             NO_HISTOGRAM_LOGGER.warn()
                     .setMessage("Expected to publish histogram, but none found")
@@ -384,11 +389,23 @@ public final class KairosDbSink extends HttpPostSink {
                     + "/status";
             try {
                 // Value for condition threshold
-                serializeConditionThreshold(completeChunks, currentChunk, chunkStream, condition, conditionName, currentChunkPopulationSize);
+                serializeConditionThreshold(
+                        completeChunks,
+                        currentChunk,
+                        chunkStream,
+                        condition,
+                        conditionName,
+                        currentChunkPopulationSize);
 
                 if (condition.isTriggered().isPresent()) {
                     // Value for condition trigger (or status)
-                    serializeConditionStatus(completeChunks, currentChunk, chunkStream, condition, conditionStatusName, currentChunkPopulationSize);
+                    serializeConditionStatus(
+                            completeChunks,
+                            currentChunk,
+                            chunkStream,
+                            condition,
+                            conditionStatusName,
+                            currentChunkPopulationSize);
 
                 }
             } catch (final IOException e) {

--- a/src/main/java/com/arpnetworking/tsdcore/sinks/MonitordSink.java
+++ b/src/main/java/com/arpnetworking/tsdcore/sinks/MonitordSink.java
@@ -39,6 +39,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Publishes aggregations to Monitord. This class is thread safe.
@@ -63,13 +64,13 @@ public final class MonitordSink extends HttpPostSink {
     }
 
     @Override
-    protected Collection<byte[]> serialize(final PeriodicData periodicData) {
+    protected Collection<SerializedDatum> serialize(final PeriodicData periodicData) {
         final Duration period = periodicData.getPeriod();
         final Multimap<String, AggregatedData> indexedData = prepareData(periodicData);
         final Multimap<String, Condition> indexedConditions = prepareConditions(periodicData.getConditions());
 
         // Serialize
-        final List<byte[]> serializedData = Lists.newArrayListWithCapacity(indexedData.size());
+        final List<SerializedDatum> serializedData = Lists.newArrayListWithCapacity(indexedData.size());
         final StringBuilder stringBuilder = new StringBuilder();
         for (final String key : indexedData.keySet()) {
             final Collection<AggregatedData> namedData = indexedData.get(key);
@@ -135,7 +136,9 @@ public final class MonitordSink extends HttpPostSink {
                         .append(dataBuilder.toString());
 
                 stringBuilder.setLength(stringBuilder.length() - 3);
-                serializedData.add(stringBuilder.toString().getBytes(Charset.forName("UTF-8")));
+                serializedData.add(new SerializedDatum(
+                        stringBuilder.toString().getBytes(Charset.forName("UTF-8")),
+                        Optional.empty()));
             }
         }
 

--- a/src/main/java/com/arpnetworking/tsdcore/sinks/SignalFxSink.java
+++ b/src/main/java/com/arpnetworking/tsdcore/sinks/SignalFxSink.java
@@ -64,12 +64,12 @@ public final class SignalFxSink extends HttpPostSink {
     }
 
     @Override
-    protected Collection<byte[]> serialize(final PeriodicData periodicData) {
+    protected Collection<SerializedDatum> serialize(final PeriodicData periodicData) {
         final String period = periodicData.getPeriod().toString();
         final long timestamp = periodicData.getStart().toInstant().toEpochMilli()
                 + periodicData.getPeriod().toMillis();
 
-        final List<byte[]> serializedData = Lists.newArrayList();
+        final List<SerializedDatum> serializedData = Lists.newArrayList();
         SignalFxProtocolBuffers.DataPointUploadMessage.Builder sfxMessage = SignalFxProtocolBuffers.DataPointUploadMessage.newBuilder();
         int count = 0;
         for (final AggregatedData datum : periodicData.getData()) {
@@ -86,14 +86,14 @@ public final class SignalFxSink extends HttpPostSink {
             count += Math.max(1, sfxDimensions.size());
 
             if (count >= _maxMetricDimensions) {
-                serializedData.add(sfxMessage.build().toByteArray());
+                serializedData.add(new SerializedDatum(sfxMessage.build().toByteArray(), Optional.empty()));
                 sfxMessage = SignalFxProtocolBuffers.DataPointUploadMessage.newBuilder();
                 count = 0;
             }
         }
 
         if (count > 0) {
-            serializedData.add(sfxMessage.build().toByteArray());
+            serializedData.add(new SerializedDatum(sfxMessage.build().toByteArray(), Optional.empty()));
         }
         return serializedData;
     }

--- a/src/test/java/com/arpnetworking/tsdcore/sinks/InfluxDbSinkTest.java
+++ b/src/test/java/com/arpnetworking/tsdcore/sinks/InfluxDbSinkTest.java
@@ -107,12 +107,12 @@ public final class InfluxDbSinkTest {
                 .setStart(dateTime)
                 .setDimensions(ImmutableMap.of("host", host))
                 .build();
-        final Collection<byte[]> results = influxDbSink.serialize(periodicData);
+        final Collection<HttpPostSink.SerializedDatum> results = influxDbSink.serialize(periodicData);
         Assert.assertEquals(1, results.size());
         final String expectedResponse =
             "PT5M.metric-testSerializeMerge,cluster=test-cluster,service=service-testSerializeMerge,host=test-host "
                 + "mean=0.2,count=50.0 1456361906636";
-        Assert.assertArrayEquals(expectedResponse.getBytes(StandardCharsets.UTF_8), Iterables.getFirst(results, null));
+        Assert.assertArrayEquals(expectedResponse.getBytes(StandardCharsets.UTF_8), Iterables.getFirst(results, null).getDatum());
 
     }
 
@@ -168,14 +168,14 @@ public final class InfluxDbSinkTest {
                 .setStart(dateTime)
                 .setDimensions(ImmutableMap.of("host", host))
                 .build();
-        final Collection<byte[]> results = influxDbSink.serialize(periodicData);
+        final Collection<HttpPostSink.SerializedDatum> results = influxDbSink.serialize(periodicData);
         Assert.assertEquals(1, results.size());
         final String expectedResponse =
             "PT5M.metric-testSerializeMerge2,cluster=test-cluster,service=service-testSerializeMerge,host=test-host "
                 + "count=0.2 1456361906636\n"
             + "PT5M.metric-testSerializeMerge,cluster=test-cluster,service=service-testSerializeMerge,host=test-host "
                 + "count=50.0 1456361906636";
-        Assert.assertArrayEquals(expectedResponse.getBytes(StandardCharsets.UTF_8), Iterables.getFirst(results, null));
+        Assert.assertArrayEquals(expectedResponse.getBytes(StandardCharsets.UTF_8), Iterables.getFirst(results, null).getDatum());
     }
 
     @Test
@@ -229,12 +229,12 @@ public final class InfluxDbSinkTest {
                 .setStart(dateTime)
                 .setDimensions(ImmutableMap.of("host", host))
                 .build();
-        final Collection<byte[]> results = influxDbSink.serialize(periodicData);
+        final Collection<HttpPostSink.SerializedDatum> results = influxDbSink.serialize(periodicData);
         Assert.assertEquals(1, results.size());
         final String expectedResponse =
             "PT5M.metric\\ test\\,Serialize_Merge,cluster=test\\ cluster,service=service\\ test\\,Serialize_Merge,"
                 + "host=test\\ host mean=0.2,count=50.0 1456361906636";
-        Assert.assertArrayEquals(expectedResponse.getBytes(StandardCharsets.UTF_8), Iterables.getFirst(results, null));
+        Assert.assertArrayEquals(expectedResponse.getBytes(StandardCharsets.UTF_8), Iterables.getFirst(results, null).getDatum());
 
     }
 

--- a/src/test/java/com/arpnetworking/tsdcore/sinks/KMonDSinkTest.java
+++ b/src/test/java/com/arpnetworking/tsdcore/sinks/KMonDSinkTest.java
@@ -82,7 +82,7 @@ public class KMonDSinkTest {
         final PeriodicData periodicData = TestBeanFactory.createPeriodicDataBuilder()
                 .setData(data)
                 .build();
-        final Collection<byte[]> results = monitordSink.serialize(periodicData);
+        final Collection<HttpPostSink.SerializedDatum> results = monitordSink.serialize(periodicData);
         Assert.assertEquals(1, results.size());
     }
 
@@ -110,7 +110,7 @@ public class KMonDSinkTest {
         final PeriodicData periodicData = TestBeanFactory.createPeriodicDataBuilder()
                 .setData(data)
                 .build();
-        final Collection<byte[]> results = monitordSink.serialize(periodicData);
+        final Collection<HttpPostSink.SerializedDatum> results = monitordSink.serialize(periodicData);
         Assert.assertEquals(2, results.size());
     }
 
@@ -138,7 +138,7 @@ public class KMonDSinkTest {
         final PeriodicData periodicData = TestBeanFactory.createPeriodicDataBuilder()
                 .setData(data)
                 .build();
-        final Collection<byte[]> results = monitordSink.serialize(periodicData);
+        final Collection<HttpPostSink.SerializedDatum> results = monitordSink.serialize(periodicData);
         Assert.assertEquals(2, results.size());
     }
 
@@ -165,7 +165,7 @@ public class KMonDSinkTest {
         final PeriodicData periodicData = TestBeanFactory.createPeriodicDataBuilder()
                 .setData(data)
                 .build();
-        final Collection<byte[]> results = monitordSink.serialize(periodicData);
+        final Collection<HttpPostSink.SerializedDatum> results = monitordSink.serialize(periodicData);
         Assert.assertEquals(2, results.size());
     }
 

--- a/src/test/java/com/arpnetworking/tsdcore/sinks/MonitordSinkTest.java
+++ b/src/test/java/com/arpnetworking/tsdcore/sinks/MonitordSinkTest.java
@@ -82,7 +82,7 @@ public class MonitordSinkTest {
         final PeriodicData periodicData = TestBeanFactory.createPeriodicDataBuilder()
                 .setData(data)
                 .build();
-        final Collection<byte[]> results = monitordSink.serialize(periodicData);
+        final Collection<HttpPostSink.SerializedDatum> results = monitordSink.serialize(periodicData);
         Assert.assertEquals(1, results.size());
     }
 
@@ -110,7 +110,7 @@ public class MonitordSinkTest {
         final PeriodicData periodicData = TestBeanFactory.createPeriodicDataBuilder()
                 .setData(data)
                 .build();
-        final Collection<byte[]> results = monitordSink.serialize(periodicData);
+        final Collection<HttpPostSink.SerializedDatum> results = monitordSink.serialize(periodicData);
         Assert.assertEquals(2, results.size());
     }
 
@@ -138,7 +138,7 @@ public class MonitordSinkTest {
         final PeriodicData periodicData = TestBeanFactory.createPeriodicDataBuilder()
                 .setData(data)
                 .build();
-        final Collection<byte[]> results = monitordSink.serialize(periodicData);
+        final Collection<HttpPostSink.SerializedDatum> results = monitordSink.serialize(periodicData);
         Assert.assertEquals(2, results.size());
     }
 
@@ -165,7 +165,7 @@ public class MonitordSinkTest {
         final PeriodicData periodicData = TestBeanFactory.createPeriodicDataBuilder()
                 .setData(data)
                 .build();
-        final Collection<byte[]> results = monitordSink.serialize(periodicData);
+        final Collection<HttpPostSink.SerializedDatum> results = monitordSink.serialize(periodicData);
         Assert.assertEquals(2, results.size());
     }
 


### PR DESCRIPTION
Record samplesDropped and samplesSent metrics in HttpSink based on the population size of the samples in the request entry that succeeds (for samplesSent) or fails/reject (for samplesDropped). 

Made population size as an optional field in the RequestEntry of the HttpSink queue and the population size must be calculated in the serialize method of the sink that extends HttpSink.

For this PR, only the population size is calculated for the KairosDB sink.
The other sinks that extend HttpSink must calculate their population size per request as future work based on the specific serialization method.