### PR TITLE
periodically check aggregator actors for liveliness

### DIFF
--- a/src/main/java/com/arpnetworking/clusteraggregator/GuiceModule.java
+++ b/src/main/java/com/arpnetworking/clusteraggregator/GuiceModule.java
@@ -359,6 +359,13 @@ public class GuiceModule extends AbstractModule {
     }
 
     @Provides
+    @Named("aggregator-liveliness-timeout")
+    @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD") // Invoked reflectively by Guice
+    private Duration provideLivelinessTimeout(final ClusterAggregatorConfiguration config) {
+        return config.getAggregatorLivelinessTimeout();
+    }
+
+    @Provides
     @Named("circonus-partition-set")
     @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD") // Invoked reflectively by Guice
     private PartitionSet provideDatabasePartitionSet(final Injector injector) {

--- a/src/main/java/com/arpnetworking/clusteraggregator/aggregation/AggregationRouter.java
+++ b/src/main/java/com/arpnetworking/clusteraggregator/aggregation/AggregationRouter.java
@@ -49,6 +49,7 @@ public class AggregationRouter extends AbstractActor {
      * @param reaggregationDimensions The dimensions to reaggregate over.
      * @param injectClusterAsHost Whether to inject a host dimension based on cluster.
      * @param aggregatorTimeout The time to wait from the start of the period for all data.
+     * @param livelinessTimeout How often to check that a child is still receiving data.
      * @return A new {@link Props}.
      */
     public static Props props(
@@ -57,7 +58,8 @@ public class AggregationRouter extends AbstractActor {
             final String clusterHostSuffix,
             final ImmutableSet<String> reaggregationDimensions,
             final boolean injectClusterAsHost,
-            final Duration aggregatorTimeout) {
+            final Duration aggregatorTimeout,
+            final Duration livelinessTimeout) {
         return Props.create(
                 AggregationRouter.class,
                 metricsListener,
@@ -65,7 +67,8 @@ public class AggregationRouter extends AbstractActor {
                 clusterHostSuffix,
                 reaggregationDimensions,
                 injectClusterAsHost,
-                aggregatorTimeout);
+                aggregatorTimeout,
+                livelinessTimeout);
     }
 
     /**
@@ -77,6 +80,7 @@ public class AggregationRouter extends AbstractActor {
      * @param reaggregationDimensions The dimensions to reaggregate over.
      * @param injectClusterAsHost Whether to inject a host dimension based on cluster.
      * @param aggregatorTimeout The time to wait from the start of the period for all data.
+     * @param livelinessTimeout How often to check that a child is still receiving data.
      */
     @Inject
     public AggregationRouter(
@@ -85,15 +89,18 @@ public class AggregationRouter extends AbstractActor {
             @Named("cluster-host-suffix") final String clusterHostSuffix,
             @Named("reaggregation-dimensions") final ImmutableSet<String> reaggregationDimensions,
             @Named("reaggregation-cluster-as-host") final boolean injectClusterAsHost,
-            @Named("reaggregation-timeout") final Duration aggregatorTimeout) {
-        _streamingChild = context().actorOf(
+            @Named("reaggregation-timeout") final Duration aggregatorTimeout,
+            @Named("aggregator-liveliness-timeout") final Duration livelinessTimeout) {
+            _streamingChild = context().actorOf(
                 StreamingAggregator.props(
                         periodicStatistics,
                         emitter,
                         clusterHostSuffix,
                         reaggregationDimensions,
                         injectClusterAsHost,
-                        aggregatorTimeout),
+                        aggregatorTimeout,
+                        livelinessTimeout
+                ),
                 "streaming");
         context().setReceiveTimeout(FiniteDuration.apply(30, TimeUnit.MINUTES));
     }

--- a/src/main/java/com/arpnetworking/clusteraggregator/configuration/ClusterAggregatorConfiguration.java
+++ b/src/main/java/com/arpnetworking/clusteraggregator/configuration/ClusterAggregatorConfiguration.java
@@ -551,17 +551,17 @@ public final class ClusterAggregatorConfiguration {
 
         /**
          * How often an aggregator actor should check for liveliness. An actor is considered live
-         * if any data is received between subsequent checks.
+         * if any data is received between consecutive checks.
          *
-         * This control is useful for culling aggregator instances for very infrequently occurring
-         * dimension sets, especially if the application is long-lived.
+         * This control is useful for culling instances which aggregate very infrequent dimension
+         * sets, especially if the application itself is long-lived.
          *
          * This must be greater than the reaggregation timeout, otherwise an actor could be
          * incorrectly marked as stale before flushing its data.
          *
          * Optional. Defaults to twice the reaggregation timeout. Cannot be null.
          *
-         * @param value Timeout from period start to wait for all data to arrive.
+         * @param value Timeout between consecutive liveliness checks.
          * @return This instance of {@link Builder}.
          */
         public Builder setAggregatorLivelinessTimeout(final Duration value) {
@@ -604,7 +604,7 @@ public final class ClusterAggregatorConfiguration {
         }
 
         /**
-         * Validate that the aggregator liveliness timeout is less than the reaggregation timeout.
+         * Validate that the aggregator liveliness timeout is greater than the reaggregation timeout.
          *
          * @param aggregatorLivelinessTimeout the configured liveliness timeout
          * @return true if the given value is valid

--- a/src/main/java/com/arpnetworking/clusteraggregator/configuration/ClusterAggregatorConfiguration.java
+++ b/src/main/java/com/arpnetworking/clusteraggregator/configuration/ClusterAggregatorConfiguration.java
@@ -603,9 +603,15 @@ public final class ClusterAggregatorConfiguration {
             return this;
         }
 
+        /**
+         * Validate that the aggregator liveliness timeout is less than the reaggregation timeout.
+         *
+         * @param aggregatorLivelinessTimeout the configured liveliness timeout
+         * @return true if the given value is valid
+         */
         @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD", justification = "invoked reflectively by @ValidateWithMethod")
         public boolean validateAggregatorLivelinessTimeout(final Duration aggregatorLivelinessTimeout) {
-            return aggregatorLivelinessTimeout.compareTo(_reaggregationTimeout) < 0;
+            return aggregatorLivelinessTimeout.compareTo(_reaggregationTimeout) > 0;
         }
 
         @NotNull
@@ -655,7 +661,7 @@ public final class ClusterAggregatorConfiguration {
         @NotNull
         private Duration _reaggregationTimeout = Duration.ofMinutes(1);
         @NotNull
-        @ValidateWithMethod(methodName = "validateAggregatorLivelinessTimeout", parameterType=Duration.class)
+        @ValidateWithMethod(methodName = "validateAggregatorLivelinessTimeout", parameterType = Duration.class)
         private Duration _aggregatorLivelinessTimeout = _reaggregationTimeout.multipliedBy(2);
         @NotNull
         private File _hostPipelineConfiguration;


### PR DESCRIPTION
CAGG will constantly start up StreamingAggregator actors throughout the cluster as it receives new metric dimension sets. If these dimension sets are infrequent, the actor will aggregate that single occurrence and live for the remaining lifetime of the application. This can lead to a slowly growing pool of actors not doing any meaningful work.

To fix this, we add a new configuration option, **aggregatorLivelinessTimeout**, which controls how often a StreamingAggregator actor will check if it should shutdown due to lack of data. If the actor has not received data between consecutive checks, it will request shutdown. Note that in the event an actor is shutdown for a dimension set that will occur again, the cluster sharding manager will just recreate the actor.