### PR TITLE
Fix logging too old data.

### DIFF
--- a/src/main/java/com/arpnetworking/clusteraggregator/aggregation/StreamingAggregator.java
+++ b/src/main/java/com/arpnetworking/clusteraggregator/aggregation/StreamingAggregator.java
@@ -237,10 +237,11 @@ public class StreamingAggregator extends AbstractActorWithTimers {
         final ZonedDateTime periodStart = ZonedDateTime.parse(data.getPeriodStart());
         if (periodStart.plus(_period).plus(_aggregatorTimeout).isBefore(ZonedDateTime.now())) {
             // We got a bit of data that is too old for us to aggregate.
+            @Nullable final StreamingAggregationBucket firstBucket = _aggBuckets.getFirst();
             WORK_TOO_OLD_LOGGER.warn()
                     .setMessage("Received a work item that is too old to aggregate")
                     .addData("start", periodStart)
-                    .addData("firstStart", _aggBuckets.getFirst().getPeriodStart())
+                    .addData("firstStart", firstBucket == null ? null : firstBucket.getPeriodStart())
                     .addData("metric", data.getMetric())
                     .addData("dimensions", data.getDimensionsMap())
                     .addContext("actor", self())


### PR DESCRIPTION
Addresses:

```
{"time":"2021-05-18T21:43:08.278Z","name":"log","level":"crit","data":{"message":null},"exception":{"type":"java.util.NoSuchElementException","message":null,"backtrace":["at java.util.LinkedList.getFirst(LinkedList.java:244)","at com.arpnetworking.clusteraggregator.aggregation.StreamingAggregator.processAggregationMessage(StreamingAggregator.java:243)","at com.arpnetworking.clusteraggregator.aggregation.StreamingAggregator.lambda$1(StreamingAggregator.java:132)","at akka.japi.pf.UnitCaseStatement.apply(CaseStatements.scala:24)","at akka.japi.pf.UnitCaseStatement.apply(CaseStatements.scala:20)","at scala.PartialFunction.applyOrElse(PartialFunction.scala:123)","at scala.PartialFunction.applyOrElse$(PartialFunction.scala:122)","at akka.japi.pf.UnitCaseStatement.applyOrElse(CaseStatements.scala:20)","at scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:171)","at akka.actor.Actor.aroundReceive(Actor.scala:539)","at akka.actor.Actor.aroundReceive$(Actor.scala:537)","at akka.actor.AbstractActorWithTimers.akka$actor$Timers$$super$aroundReceive(Timers.scala:67)","at akka.actor.Timers.aroundReceive(Timers.scala:55)","at akka.actor.Timers.aroundReceive$(Timers.scala:40)","at akka.actor.AbstractActorWithTimers.aroundReceive(Timers.scala:67)","at akka.actor.ActorCell.receiveMessage(ActorCell.scala:614)","at akka.actor.ActorCell.invoke(ActorCell.scala:583)","at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:268)","at akka.dispatch.Mailbox.run(Mailbox.scala:229)","at akka.dispatch.Mailbox.exec(Mailbox.scala:241)","at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)","at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)","at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)","at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)"],"data":{"_id":"aa4bf91","_class":"java.util.NoSuchElementException"}},"context":{"host":"iad8a-rp8-8a.sjc.dropbox.com","processId":"7","threadId":"Metrics-akka.actor.default-dispatcher-89","logger":"a.a.OneForOneStrategy"},"id":"ccda5ad1-7fa2-4b33-a858-691864ce4637","version":"0"}

{"time":"2021-05-18T21:43:08.278Z","name":"log","level":"crit","data":{"message":"Aggregator crashing","triggeringMessage":{"_id":"25a956e4","_class":"com.arpnetworking.metrics.aggregation.protocol.Messages$StatisticSetRecord"}},"exception":{"type":"java.util.NoSuchElementException","message":null,"backtrace":["at java.util.LinkedList.getFirst(LinkedList.java:244)","at com.arpnetworking.clusteraggregator.aggregation.StreamingAggregator.processAggregationMessage(StreamingAggregator.java:243)","at com.arpnetworking.clusteraggregator.aggregation.StreamingAggregator.lambda$1(StreamingAggregator.java:132)","at akka.japi.pf.UnitCaseStatement.apply(CaseStatements.scala:24)","at akka.japi.pf.UnitCaseStatement.apply(CaseStatements.scala:20)","at scala.PartialFunction.applyOrElse(PartialFunction.scala:123)","at scala.PartialFunction.applyOrElse$(PartialFunction.scala:122)","at akka.japi.pf.UnitCaseStatement.applyOrElse(CaseStatements.scala:20)","at scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:171)","at akka.actor.Actor.aroundReceive(Actor.scala:539)","at akka.actor.Actor.aroundReceive$(Actor.scala:537)","at akka.actor.AbstractActorWithTimers.akka$actor$Timers$$super$aroundReceive(Timers.scala:67)","at akka.actor.Timers.aroundReceive(Timers.scala:55)","at akka.actor.Timers.aroundReceive$(Timers.scala:40)","at akka.actor.AbstractActorWithTimers.aroundReceive(Timers.scala:67)","at akka.actor.ActorCell.receiveMessage(ActorCell.scala:614)","at akka.actor.ActorCell.invoke(ActorCell.scala:583)","at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:268)","at akka.dispatch.Mailbox.run(Mailbox.scala:229)","at akka.dispatch.Mailbox.exec(Mailbox.scala:241)","at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)","at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)","at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)","at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)"],"data":{"_id":"aa4bf91","_class":"java.util.NoSuchElementException"}},"context":{"host":"iad8a-rp8-8a.sjc.dropbox.com","processId":"7","threadId":"Metrics-akka.actor.default-dispatcher-86","logger":"c.a.c.a.StreamingAggregator","actor":"Actor[akka://Metrics/system/sharding/Aggregator/shard_1223/firehose-etl%7C%7Cfirehose-etl%7C%7Cdesktop_perf%2Flocal_view_navigation%2Fapp_code_start%7C%7CPT1M%7C%7C_artifact_name%3Ddropbox-desktop%7C%7C_artifact_version%3D120%7C%7C_environment%3Dstable%7C%7C_namespace%3Ddesktop_perf%7C%7C_os_name%3DMAC%7C%7C_region%3DNorth+and+Central+America%7C%7Cbuild_id%3Dmain%7C%7Cchromium_host%3Dlegacy%7C%7Cfeature%3Dfeatures%2Ftray%7C%7Cpreload%3DFalse/streaming#468099181]","line":"215","file":"StreamingAggregator.java","class":"com.arpnetworking.clusteraggregator.aggregation.StreamingAggregator"},"id":"597d608b-78c8-43d0-928d-120324fbd322","version":"0"}
```